### PR TITLE
Fix overloaded funtion to call I2C master begin

### DIFF
--- a/src/M5_Scales.cpp
+++ b/src/M5_Scales.cpp
@@ -5,7 +5,7 @@ bool M5_Scales::begin(TwoWire *wire, uint8_t sda, uint8_t scl, uint8_t addr) {
     _addr = addr;
     _sda  = sda;
     _scl  = scl;
-    _wire->begin(_sda, _scl, 400000UL);
+    _wire->begin((int)_sda, (int)_scl, 400000UL);
     delay(10);
     _wire->beginTransmission(_addr);
     uint8_t error = _wire->endTransmission();


### PR DESCRIPTION
Newer ESP32 Arduino libraries added an overloaded begin() function to setup an I2C slave. The two begin functions have the following parameter types:

- I2C master: bool TwoWire::begin(int sda = -1, int scl = -1, uint32_t frequency = 0U)
- I2C slave: bool TwoWire::begin(uint8_t slaveAddr, int sda = -1, int scl = -1, uint32_t frequency = 0U)

The current implementation, where sda and scl are defined as uint8_t, incorrectly calls the begin() for an I2C slave. The proposed modification fixes that issue and forces the linker to call the begin() for an I2C master as intended.

Note: there are probably additional unit libraries which need the same fix.